### PR TITLE
fix: remove requirement for issue label

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,10 +133,10 @@ function checkIssue(issue, log) {
     return false;
   }
 
-  if (issue.labels.length === 0) {
-    log.error("The issue is not labeled.");
-    return false;
-  }
+  //if (issue.labels.length === 0) {
+    //log.error("The issue is not labeled.");
+    //return false;
+  //}
 
   //if (!issue.milestone) {
     //log.error("The issue is not linked to a milestone.");


### PR DESCRIPTION
Comment out check that there's a label on the issue. We don't want this right now, but might in the future.